### PR TITLE
Add markdown formatter to docs output

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -75,7 +75,7 @@ defmodule DigitalToken.MixProject do
       main: "readme",
       extras: ["README.md", "CHANGELOG.md", "LICENSE.md"],
       logo: "logo.png",
-      formatters: ["html"],
+      formatters: ["html", "markdown"],
       skip_undefined_reference_warnings_on: ["changelog", "CHANGELOG.md"]
     ]
   end


### PR DESCRIPTION
ex_doc v0.40.0 added a Markdown formatter and generates `llms.txt` by default. Because this project pins an explicit `formatters:` list, that new default does not apply.

This adds `"markdown"` to the existing HTML-only list. HTML output is unchanged, and no other formatter is added or removed.

Verified with `mix docs`: the build emits `doc/llms.txt` and Markdown pages alongside the HTML output. `mix test` has one pre-existing doctest failure for `DigitalToken.symbol("ETH", 4)`; the same failure occurs on unmodified `main`.

This PR was generated from [Elixir's retrieval gap is a rollout problem, not an access problem](https://phxagents.dev/research/elixir-retrieval-gap/).

— Oliver’s AMP